### PR TITLE
修改交易接口重连时，错误的入参值

### DIFF
--- a/vnpy_xt/xt_gateway.py
+++ b/vnpy_xt/xt_gateway.py
@@ -624,7 +624,7 @@ class XtTdApi(XtQuantTraderCallback):
 
         # 尝试重连，重连需要更换session_id
         session: int = int(float(datetime.now().strftime("%H%M%S.%f")) * 1000)
-        connect_result: int = self.connect(self.path, self.accountid, self.account_type, session)
+        connect_result: int = self.connect(self.path, self.account_id, self.account_type, session)
 
         if connect_result:
             self.gateway.write_log("交易接口重连失败")


### PR DESCRIPTION

## 改进内容

类中的实际变量为account_id，而非accountid，修正了拼写错误，避免逻辑执行不正确
